### PR TITLE
Switch from arkose.org to https://victoriabrook.github.io/arkose/

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-arkose.org

--- a/_config.yml
+++ b/_config.yml
@@ -3,9 +3,9 @@ title: Arkose
 subtitle: 
 email: team@arkose.org
 description: 
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "/arkose" # the subpath of your site, e.g. /blog
 permalink: pretty
-url: https://arkose.org # the base hostname & protocol for your site
+url: https://victoriabrook.github.io # the base hostname & protocol for your site
 applyurl: https://airtable.com/appPMHlJ6Z7XkDSEi/shr8RR0ZkJr22Ub3Z
 author:
 


### PR DESCRIPTION
@victoriaBrook, merge this PR after accepting the GitHub repository transfer from Vael.

This PR updates the site config with the new URL settings, removes the arkose.org custom domain from this repo's GitHub Pages settings, making it instead available at its default location, which (after the repo ownership transfer) will be https://victoriabrook.github.io/arkose/